### PR TITLE
Add Contributor's Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,11 @@ The following is a step-by-step guide to getting your cookbook idea
 hosted on the [Project Pythia Cookbooks gallery](https://projectpythia.org/cookbook-gallery.html).
 
 1. Use the template
+    1. If you don't already have a GitHub account, create one by following the [Getting Started with GitHub guide](https://foundations.projectpythia.org/foundations/getting-started-github.html)
     1. On https://github.com/ProjectPythiaTutorials/cookbook-template, click "Use this template"
     1. Create the repo under your account with a descriptive name, followed by `-cookbook` (e.g. `hydrology-cookbook`, `hpc-cookbook`, `cesm-cookbook`, etc.)
     1. In the settings, enable GitHub Pages and make the source `gh-pages/(root)`
-    1. See the [GitHub tutorial in Foundations](https://foundations.projectpythia.org/foundations/getting-started-github.html) for how to set up a clone
+    1. Clone the repo in your local workspace (see the [Cloning and Forking a Repository tutorial in Foundations](https://foundations.projectpythia.org/foundations/github/github-cloning-forking.html) for how to set up a clone) and `cd` into your cookbook directory
 1. Create the environment
     1. Edit `environment.yml`: change the name to `<your-cookbook-name>-dev` (e.g. `cesm-cookbook-dev`) and add all required libraries and other dependencies under `dependencies:`. Commit the changes
     1. Create the Conda environment with `conda env create -f environment.yml`. If it crashes, try running `conda config --set channel_priority strict`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ hosted on the [Project Pythia Cookbooks gallery](https://projectpythia.org/cookb
 1. Use the template
     1. On https://github.com/ProjectPythiaTutorials/cookbook-template, click "Use this template"
     1. Create the repo under your account with a descriptive name, followed by `-cookbook` (e.g. `hydrology-cookbook`, `hpc-cookbook`, `cesm-cookbook`, etc.)
+    1. In the settings, enable GitHub Pages and make the source `gh-pages/(root)`
     1. See the [GitHub tutorial in Foundations](https://foundations.projectpythia.org/foundations/getting-started-github.html) for how to set up a clone
 1. Create the environment
     1. Edit `environment.yml`: change the name to `<your-cookbook-name>-dev` (e.g. `cesm-cookbook-dev`) and add all required libraries and other dependencies under `dependencies:`. Commit the changes
@@ -21,6 +22,7 @@ hosted on the [Project Pythia Cookbooks gallery](https://projectpythia.org/cookb
     1. Using the notebook template, add your content. Add folders to organize notebooks into sections if applicable
     1. Add the notebooks to `_toc.yml`. See `radar-cookbook/notebooks/_toc.yml` for syntax
     1. Change `README.md` to include your cookbook title, various badges, a sentence or two describing the cookbook, and a link to the landing page. See the [Radar Cookbook](https://github.com/ProjectPythiaTutorials/radar-cookbook/blob/main/README.md) for an example
+    1. When you open a PR on your cookbook repo, the github-actions bot will comment a link to a preview of your cookbook
 1. Transfer cookbook to the [ProjectPythiaTutorials](https://github.com/ProjectPythiaTutorials) organization
     1. Navigate to the settings of your repo, scroll down to the Danger Zone, and click "Transfer"
         1. For ProjectPythiaTutorials owners or members: type "ProjectPythiaTutorials", confirm, and transfer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,18 +12,18 @@ hosted on the [Project Pythia Cookbooks gallery](https://projectpythia.org/cookb
 1. Use the template
     1. If you don't already have a GitHub account, create one by following the [Getting Started with GitHub guide](https://foundations.projectpythia.org/foundations/getting-started-github.html)
     1. On https://github.com/ProjectPythiaTutorials/cookbook-template, click "Use this template"
-    1. Create the repo under your account with a descriptive name, followed by `-cookbook` (e.g. `hydrology-cookbook`, `hpc-cookbook`, `cesm-cookbook`, etc.)
-    1. In the settings, enable GitHub Pages and make the source `gh-pages/(root)`
-    1. Clone the repo in your local workspace (see the [Cloning and Forking a Repository tutorial in Foundations](https://foundations.projectpythia.org/foundations/github/github-cloning-forking.html) for how to set up a clone) and `cd` into your cookbook directory
+    1. Create the repo under your account with a descriptive name, followed by `-cookbook` (e.g. `hydrology-cookbook`, `hpc-cookbook`, `cesm-cookbook`, etc.) by entering a name into the "Repository name" field and clicking on "Create repository from template"
+    1. Your browser should be directed to the newly created repository under your GitHub account. Under Settings, enable GitHub Pages by changing the Source from "None" to `gh-pages` and clicking on "Save"
+    1. [Clone the repo](https://foundations.projectpythia.org/foundations/github/github-cloning-forking.html) in your local workspace and `cd` into your cookbook directory
 1. Create the environment
     1. Edit `environment.yml`: change the name to `<your-cookbook-name>-dev` (e.g. `cesm-cookbook-dev`) and add all required libraries and other dependencies under `dependencies:`. Commit the changes
     1. Create the Conda environment with `conda env create -f environment.yml`. If it crashes, try running `conda config --set channel_priority strict`
     1. Activate your environment with `conda activate <env-name>`
 1. Add content
-    1. Using the notebook template, add your content. Add folders to organize notebooks into sections if applicable
-    1. Add the notebooks to `_toc.yml`. See `radar-cookbook/notebooks/_toc.yml` for syntax
+    1. After [creating a new git branch](https://foundations.projectpythia.org/foundations/github/git-branches.html), edit (and duplicate as necessary) the notebook template `notebooks/notebook-template.ipynb` to add your content. Add folders to organize notebooks into sections if applicable
+    1. Add the notebooks to `_toc.yml`. See [`radar-cookbook/notebooks/_toc.yml`](https://github.com/ProjectPythiaTutorials/radar-cookbook/blob/main/notebooks/_toc.yml) for syntax
     1. Change `README.md` to include your cookbook title, various badges, a sentence or two describing the cookbook, and a link to the landing page. See the [Radar Cookbook](https://github.com/ProjectPythiaTutorials/radar-cookbook/blob/main/README.md) for an example
-    1. When you open a PR on your cookbook repo, the github-actions bot will comment a link to a preview of your cookbook
+    1. Commit your changes with git, and [open a Pull Request](https://foundations.projectpythia.org/foundations/github/github-pull-request.html) on your cookbook repo. When you open a PR there, the github-actions bot will comment a link to a preview of your cookbook
 1. Transfer cookbook to the [ProjectPythiaTutorials](https://github.com/ProjectPythiaTutorials) organization
     1. Navigate to the settings of your repo, scroll down to the Danger Zone, and click "Transfer"
         1. For ProjectPythiaTutorials owners or members: type "ProjectPythiaTutorials", confirm, and transfer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ hosted on the [Project Pythia Cookbooks gallery](https://projectpythia.org/cookb
 1. Use the template
     1. If you don't already have a GitHub account, create one by following the [Getting Started with GitHub guide](https://foundations.projectpythia.org/foundations/getting-started-github.html)
     1. On https://github.com/ProjectPythiaTutorials/cookbook-template, click "Use this template"
+    1. Choose "Include all branches"
     1. Create the repo under your account with a descriptive name, followed by `-cookbook` (e.g. `hydrology-cookbook`, `hpc-cookbook`, `cesm-cookbook`, etc.) by entering a name into the "Repository name" field and clicking on "Create repository from template"
     1. Your browser should be directed to the newly created repository under your GitHub account. Under Settings, enable GitHub Pages by changing the Source from "None" to `gh-pages` and clicking on "Save"
     1. [Clone the repo](https://foundations.projectpythia.org/foundations/github/github-cloning-forking.html) in your local workspace and `cd` into your cookbook directory

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,25 +3,25 @@
 Project Pythia Cookbooks are collections of more advanced and domain-specific example
 workflows building on top of [Pythia Foundations](https://foundations.projectpythia.org/landing-page.html). 
 They are [geoscience](https://en.wikipedia.org/wiki/Earth_science)-focused
-and should direct the reader towards the Foundations material for any required
+and should direct the reader towards the [Foundations material](https://foundations.projectpythia.org/landing-page.html) for any required
 background knowledge. 
 
 The following is a step-by-step guide to getting your cookbook idea
-hosted on the Project Pythia website.
+hosted on the [Project Pythia Cookbooks gallery](https://projectpythia.org/cookbook-gallery.html).
 
 1. Use the template
     1. On https://github.com/ProjectPythiaTutorials/cookbook-template, click "Use this template"
     1. Create the repo under your account with a descriptive name, followed by `-cookbook` (e.g. `hydrology-cookbook`, `hpc-cookbook`, `cesm-cookbook`, etc.)
     1. See the [GitHub tutorial in Foundations](https://foundations.projectpythia.org/foundations/getting-started-github.html) for how to set up a clone
 1. Create the environment
-    1. Edit `environment.yml`: change the name to `<your-cookbook-name>-dev` and add all required libraries and other dependencies under `dependencies:`. Commit the changes
+    1. Edit `environment.yml`: change the name to `<your-cookbook-name>-dev` (e.g. `cesm-cookbook-dev`) and add all required libraries and other dependencies under `dependencies:`. Commit the changes
     1. Create the Conda environment with `conda env create -f environment.yml`. If it crashes, try running `conda config --set channel_priority strict`
     1. Activate your environment with `conda activate <env-name>`
 1. Add content
     1. Using the notebook template, add your content. Add folders to organize notebooks into sections if applicable
     1. Add the notebooks to `_toc.yml`. See `radar-cookbook/notebooks/_toc.yml` for syntax
-    1. Change `README.md` to include your cookbook title, various badges, a sentence or two describing the cookbook, and a link to the landing page. See the [Radar Cookbook](https://github.com/ProjectPythiaTutorials/radar-cookbook/blob/main/README.md) for formatting
-1. Transfer cookbook to [ProjectPythiaTutorials](https://github.com/ProjectPythiaTutorials)
+    1. Change `README.md` to include your cookbook title, various badges, a sentence or two describing the cookbook, and a link to the landing page. See the [Radar Cookbook](https://github.com/ProjectPythiaTutorials/radar-cookbook/blob/main/README.md) for an example
+1. Transfer cookbook to the [ProjectPythiaTutorials](https://github.com/ProjectPythiaTutorials) organization
     1. Navigate to the settings of your repo, scroll down to the Danger Zone, and click "Transfer"
         1. For ProjectPythiaTutorials owners or members: type "ProjectPythiaTutorials", confirm, and transfer.
         1. For outside contributors: 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Project Pythia Cookbook Contributor's Guide
 
 Project Pythia Cookbooks are collections of more advanced and domain-specific example
-workflows building on top of Pythia Foundations. 
+workflows building on top of [Pythia Foundations](https://foundations.projectpythia.org/landing-page.html). 
 They are [geoscience](https://en.wikipedia.org/wiki/Earth_science)-focused
-and should point the reader towards the Foundations material for any required
+and should direct the reader towards the Foundations material for any required
 background knowledge. 
 
 The following is a step-by-step guide to getting your cookbook idea
@@ -12,17 +12,19 @@ hosted on the Project Pythia website.
 1. Use the template
     1. On https://github.com/ProjectPythiaTutorials/cookbook-template, click "Use this template"
     1. Create the repo under your account with a descriptive name, followed by `-cookbook` (e.g. `hydrology-cookbook`, `hpc-cookbook`, `cesm-cookbook`, etc.)
-    1. See the GitHub tutorial in Foundations for how to set up a clone
+    1. See the [GitHub tutorial in Foundations](https://foundations.projectpythia.org/foundations/getting-started-github.html) for how to set up a clone
 1. Create the environment
-    1. Edit `environment.yml`: change the name to `<your-cookbook-name>-dev` and add all required libraries and other dependencies under `dependencies:`
-    1. Create the Conda environment with `conda env create --file=environment.yml`. If it crashes, try running `conda config --set channel_priority strict`
+    1. Edit `environment.yml`: change the name to `<your-cookbook-name>-dev` and add all required libraries and other dependencies under `dependencies:`. Commit the changes
+    1. Create the Conda environment with `conda env create -f environment.yml`. If it crashes, try running `conda config --set channel_priority strict`
     1. Activate your environment with `conda activate <env-name>`
 1. Add content
-    1. Using the notebook template, add your content. Add folders to organize notebooks into sections
-    1. Add notebooks to `_toc.yml`. See `radar-cookbook/notebooks/_toc.yml` for syntax
-    1. Change `README.md` to include your cookbook title, various badges, a sentence or two describing the cookbook, and a link to the landing page. 
+    1. Using the notebook template, add your content. Add folders to organize notebooks into sections if applicable
+    1. Add the notebooks to `_toc.yml`. See `radar-cookbook/notebooks/_toc.yml` for syntax
+    1. Change `README.md` to include your cookbook title, various badges, a sentence or two describing the cookbook, and a link to the landing page. See the [Radar Cookbook](https://github.com/ProjectPythiaTutorials/radar-cookbook/blob/main/README.md) for formatting
 1. Transfer cookbook to [ProjectPythiaTutorials](https://github.com/ProjectPythiaTutorials)
-    1. Navigate to the settings, scroll down to the Danger Zone, and click "Transfer"
+    1. Navigate to the settings of your repo, scroll down to the Danger Zone, and click "Transfer"
         1. For ProjectPythiaTutorials owners or members: type "ProjectPythiaTutorials", confirm, and transfer.
-        1. For outside contributors: type the username of an owner or member. They will then tranfer it to ProjectPythiaTutorials and give you write permissions to that repo.
- 
+        1. For outside contributors: 
+            1. Contact an owner of ProjectPythiaTutorials to be added as an outside collaborator. Then transfer to ProjectPythiaTutorials; or
+            1. Type the username of an owner or member. They will then tranfer it to ProjectPythiaTutorials and add you as an outside collaborator on that repo
+    1. Open issues, PRs, and continue making edits as necessary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Project Pythia Cookbook Contributor's Guide
+
+Project Pythia Cookbooks are collections of more advanced and domain-specific example
+workflows building on top of Pythia Foundations. 
+They are [geoscience](https://en.wikipedia.org/wiki/Earth_science)-focused
+and should point the reader towards the Foundations material for any required
+background knowledge. 
+
+The following is a step-by-step guide to getting your cookbook idea
+hosted on the Project Pythia website.
+
+1. Use the template
+    1. On https://github.com/ProjectPythiaTutorials/cookbook-template, click "Use this template"
+    1. Create the repo under your account with a descriptive name, followed by `-cookbook` (e.g. `hydrology-cookbook`, `hpc-cookbook`, `cesm-cookbook`, etc.)
+    1. See the GitHub tutorial in Foundations for how to set up a clone
+1. Create the environment
+    1. Edit `environment.yml`: change the name to `<your-cookbook-name>-dev` and add all required libraries and other dependencies under `dependencies:`
+    1. Create the Conda environment with `conda env create --file=environment.yml`. If it crashes, try running `conda config --set channel_priority strict`
+    1. Activate your environment with `conda activate <env-name>`
+1. Add content
+    1. Using the notebook template, add your content. Add folders to organize notebooks into sections
+    1. Add notebooks to `_toc.yml`. See `radar-cookbook/notebooks/_toc.yml` for syntax
+    1. Change `README.md` to include your cookbook title, various badges, a sentence or two describing the cookbook, and a link to the landing page. 
+1. Transfer cookbook to [ProjectPythiaTutorials](https://github.com/ProjectPythiaTutorials)
+    1. Navigate to the settings, scroll down to the Danger Zone, and click "Transfer"
+        1. For ProjectPythiaTutorials owners or members: type "ProjectPythiaTutorials", confirm, and transfer.
+        1. For outside contributors: type the username of an owner or member. They will then tranfer it to ProjectPythiaTutorials and give you write permissions to that repo.
+ 

--- a/README.md
+++ b/README.md
@@ -6,31 +6,4 @@ This repository includes all the basic infrastructure to create your content and
 
 You can use the `notebook-template` in `/notebooks` as your content template!
 
-Once you have made your new content, add it to the table of contents (`notebooks/_toc.yml`) file, and push it to Github!
-
----
-
-## Cookbook Contributor's Guide
-
-Project Pythia Cookbooks are collections of more advanced and domain-specific example
-workflows building on top of Pythia Foundations. 
-They are [geoscience](https://en.wikipedia.org/wiki/Earth_science)-focused
-and should point the reader towards the Foundations material for any required
-background knowledge. 
-
-The following is a step-by-step guide to getting your cookbook idea
-published on the Project Pythia website.
-
-1. Use the template
-    1. On https://github.com/ProjectPythiaTutorials/cookbook-template, click "Use this template"
-    1. Create the repo under your account with a descriptive name, followed by `-cookbook` (e.g. `hydrology-cookbook`, `hpc-cookbook`, `cesm-cookbook`, etc.)
-    1. See the GitHub tutorial in Foundations for how to set up a clone
-1. Create the environment
-    1. Edit `environment.yml`: change the name to `<your-cookbook-name>-dev` and add all required libraries and other dependencies under `dependencies:`
-    1. Create the Conda environment with `conda env create --file=environment.yml`
-    1. Activate your environment with `conda activate <env-name>`
-1. Additional infrastructure changes
-    1. Add badges
-1. Add notebooks
-    1. Using the notebook template, add your content. Add folders to organize notebooks into sections
-    1. Add notebooks to `_toc.yml`. See `radar-cookbook/notebooks/_toc.yml` for syntax
+Once you have made your new content, add it to the table of contents (`notebooks/_toc.yml`) file, and push it to Github!     

--- a/README.md
+++ b/README.md
@@ -7,3 +7,30 @@ This repository includes all the basic infrastructure to create your content and
 You can use the `notebook-template` in `/notebooks` as your content template!
 
 Once you have made your new content, add it to the table of contents (`notebooks/_toc.yml`) file, and push it to Github!
+
+---
+
+## Cookbook Contributor's Guide
+
+Project Pythia Cookbooks are collections of more advanced and domain-specific example
+workflows building on top of Pythia Foundations. 
+They are [geoscience](https://en.wikipedia.org/wiki/Earth_science)-focused
+and should point the reader towards the Foundations material for any required
+background knowledge. 
+
+The following is a step-by-step guide to getting your cookbook idea
+published on the Project Pythia website.
+
+1. Use the template
+    1. On https://github.com/ProjectPythiaTutorials/cookbook-template, click "Use this template"
+    1. Create the repo under your account with a descriptive name, followed by `-cookbook` (e.g. `hydrology-cookbook`, `hpc-cookbook`, `cesm-cookbook`, etc.)
+    1. See the GitHub tutorial in Foundations for how to set up a clone
+1. Create the environment
+    1. Edit `environment.yml`: change the name to `<your-cookbook-name>-dev` and add all required libraries and other dependencies under `dependencies:`
+    1. Create the Conda environment with `conda env create --file=environment.yml`
+    1. Activate your environment with `conda activate <env-name>`
+1. Additional infrastructure changes
+    1. Add badges
+1. Add notebooks
+    1. Using the notebook template, add your content. Add folders to organize notebooks into sections
+    1. Add notebooks to `_toc.yml`. See `radar-cookbook/notebooks/_toc.yml` for syntax


### PR DESCRIPTION
Here's a first draft of the Contributor's Guide. The last step involves transferring the cookbook repo to this organization and adding the author as a member or outside collaborator, which should work fine for the hackathon. 