### PR TITLE
Different action

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -23,11 +23,8 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Download Artifact Book
-        uses: dawidd6/action-download-artifact@v2.21.1
+        uses: actions/download-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: build-book.yaml
-          commit: ${{ github.sha }}
           name: book-zip-${{ github.event.number }}
 
       - name: Unzip the book

--- a/notebooks/landing-page.md
+++ b/notebooks/landing-page.md
@@ -1,7 +1,5 @@
 # (Replace_with_your_title) Cookbook
 
-**IGNORE THIS TEXT**
-
 This Project Pythia Cookbook covers ... (replace `...` with the main subject of your cookbook ... e.g., *working with radar data in Python*)
 
 ## Motivation


### PR DESCRIPTION
An attempt to address #9 by switching to using https://github.com/actions/download-artifact rather than https://github.com/dawidd6/action-download-artifact for the `deploy-book.yml` workflow.

This *should* work ok because the upload and download steps occur within the same workflow.

(Also gets rid of the dumb text edit introduced in #15)