### PR TITLE
Use status badge for nightly-build action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Cookbook Template
 
-[![build-book](https://github.com/ProjectPythiaTutorials/cookbook-template/actions/workflows/build-book.yaml/badge.svg)](https://github.com/ProjectPythiaTutorials/cookbook-template/actions/workflows/build-book.yaml)
-[![link-checker](https://github.com/ProjectPythiaTutorials/cookbook-template/actions/workflows/link-checker.yaml/badge.svg)](https://github.com/ProjectPythiaTutorials/cookbook-template/actions/workflows/link-checker.yaml)
+[![nightly-build](https://github.com/ProjectPythiaTutorials/cookbook-template/actions/workflows/nightly-build.yaml/badge.svg)](https://github.com/ProjectPythiaTutorials/cookbook-template/actions/workflows/nightly-build.yaml)
 
 This is a template for creating [Project Pythia](https://projectpythia.org) Cookbooks.
 


### PR DESCRIPTION
The badges on the README page from #18 are not showing any status because the `build-book` and `link-checker` workflows are never run directly (rather they are called as reusable actions by other workflows).

This PR replaces them with a status badge for the `nightly-build` workflow.