### PR TITLE
Change cookbook navbar link to new domain

### DIFF
--- a/notebooks/_config.yml
+++ b/notebooks/_config.yml
@@ -57,7 +57,7 @@ sphinx:
         - name: Foundations
           url: https://foundations.projectpythia.org
         - name: Cookbooks
-          url: https://projectpythia.org/cookbook-gallery.html
+          url: https://cookbooks.projectpythia.org/
         - name: Resources
           url: https://projectpythia.org/resource-gallery.html
         - name: Community


### PR DESCRIPTION
This will need to be done in all existing cookbooks as well